### PR TITLE
Dev/make resources optional

### DIFF
--- a/values.yaml
+++ b/values.yaml
@@ -84,10 +84,9 @@ serviceAccountName: default
 
 # Adjust requests and limits depending on your resources,
 # and how heavyweight your workloads are.
-memoryRequest: "512Mi"
-memoryLimit: "1Gi"
-cpuRequest: "100m"
-cpuLimit: "250m"
+resources:
+  limits: {}
+  requests: {}
 
 # Enable custom cluster PKI loading
 # https://docs.openshift.com/container-platform/4.6/networking/configuring-a-custom-pki.html

--- a/values.yaml
+++ b/values.yaml
@@ -86,7 +86,9 @@ serviceAccountName: default
 # and how heavyweight your workloads are.
 resources:
   limits: {}
-  requests: {}
+  requests:
+    cpu: 100m
+    memory: 512Mi
 
 # Enable custom cluster PKI loading
 # https://docs.openshift.com/container-platform/4.6/networking/configuring-a-custom-pki.html


### PR DESCRIPTION
- Making the limits optional instead of an enforced default reserve to more efficiently use available resources by allowing bursting.