### PR TITLE
Ensure we set memory limits

### DIFF
--- a/values.yaml
+++ b/values.yaml
@@ -85,10 +85,12 @@ serviceAccountName: default
 # Adjust requests and limits depending on your resources,
 # and how heavyweight your workloads are.
 resources:
-  limits: {}
+  limits: {
+    memory: 256Mi
+  }
   requests:
     cpu: 100m
-    memory: 512Mi
+    memory: 256Mi
 
 # Enable custom cluster PKI loading
 # https://docs.openshift.com/container-platform/4.6/networking/configuring-a-custom-pki.html


### PR DESCRIPTION
- Bursting of a pod's memory limits is a bad idea since it causes instability to the overall cluster and reallocation of more memory can cause out of memory errors. We should always set memory limits to something, and that something should be [the amount of memory requested](https://home.robusta.dev/blog/kubernetes-memory-limit).