### PR TITLE
Resetting deployment to use memory limit

### DIFF
--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -127,7 +127,7 @@ spec:
               memory: {{ .Values.memoryRequest }}
               cpu: {{ .Values.cpuRequest }}
             limits:
-              memory: {{ .Values.memoryRequest }}
+              memory: {{ .Values.memoryLimit }}
 
           # Wait until the runner service is actually listening before the pod goes into the Ready state.
           # The entrypoint script takes 5-10s to connect to GitHub and start listening for jobs.


### PR DESCRIPTION
- Resetting deployment to use memory limit after talking with the team based on our memory consumption.