### PR TITLE
recreate strategy for disk PV deployments

### DIFF
--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -26,6 +26,11 @@ spec:
         # DO NOT edit the instance label, it is used by the runner installer action to find the installed pod.
         app.kubernetes.io/instance: {{ .Release.Name }}
     spec:
+      {{- if .Values.enablePersistantVolume }}
+      strategy:
+        type: Recreate
+      {{- end }}   
+      
       serviceAccountName: {{ .Values.serviceAccountName }}
       securityContext:
         runAsNonRoot: true


### PR DESCRIPTION
When disk type persistent volumes are attached to deployments, then a `recreate` deployment strategy needs to be implemented to allow volume mount/unmount to work effectively 